### PR TITLE
update to new upstream release (and location)

### DIFF
--- a/20-tslib.conf
+++ b/20-tslib.conf
@@ -1,5 +1,0 @@
-Section "InputClass"
-        Identifier "tslib touchscreen"
-        Driver "tslib"
-        MatchIsTouchscreen "on"
-EndSection

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Christian Hesse <mail@eworm.de>
 
 pkgname=xf86-input-tslib
-pkgver=0.0.6
+pkgver=0.0.7
 pkgrel=1
 pkgdesc="X.org tslib input driver"
 arch=(arm i686 x86_64)
@@ -12,8 +12,7 @@ makedepends=('xorg-server')
 options=('!libtool')
 groups=('xorg-drivers' 'xorg')
 backup=("etc/ts.conf")
-source=("http://pengutronix.de/software/${pkgname}/download/${pkgname}-${pkgver}.tar.bz2"
-	"20-tslib.conf")
+source=("https://github.com/merge/${pkgname}/releases/download/${pkgver}/${pkgname}-${pkgver}.tar.bz2")
 
 build() {
   cd "${srcdir}/${pkgname}-${pkgver}"
@@ -21,7 +20,5 @@ build() {
   make
   make DESTDIR="${pkgdir}" install
   install -D -m644 COPYING "${pkgdir}/usr/share/licenses/${pkgname}/COPYING"
-  install -D -m644 "${srcdir}/20-tslib.conf" "${pkgdir}/etc/X11/xorg.conf.d/20-tslib.conf"
 }
-md5sums=('b7a4d2f11637ee3fcf432e044b1d017f'
-         '2c49ec053e67a17fb71ce6dc2b12b6f6')
+sha256sums=('6f23cc9702b0ae16086d364b275335c094efbf6acde57f8a030e4db5b9aece03')


### PR DESCRIPTION
This is completely untested, but updates the PKGBUILD entries to match
the newest upstream version of xf86-input-tslib

Note that the deleted config file is now included upstream